### PR TITLE
Reverse order of graph dict. Recently = At top.

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -142,7 +142,7 @@ def main(directory, cutoffDays = 7):
     maxf = float(max)
     step = maxf / WIDTH
 
-    orderedDic = collections.OrderedDict(sorted(dic.items()))
+    orderedDic = collections.OrderedDict(reversed(sorted(dic.items())))
 
     # display graph
     print()


### PR DESCRIPTION
Most people expect recent stuff to be at the top. However, this isn't the case for the graph add on. So this slight change simply reverses the order containing the dates and graph. Therefore, calling `todo` with the `graph` keyword results in this:

```
2016-01-02: ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 4
2016-01-01: ■■■■■■■■■■■■■■■■■ 2
2015-12-06: ■■■■■■■■ 1
2015-12-03: ■■■■■■■■■■■■■■■■■■■■■■■■■ 3
```

instead of this:

```
2015-12-03: ■■■■■■■■■■■■■■■■■■■■■■■■■ 3
2015-12-06: ■■■■■■■■ 1
2016-01-01: ■■■■■■■■■■■■■■■■■ 2
2016-01-02: ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 4
```
