### PR TITLE
Read tasks from todo.txt in addition to done.txt

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -30,6 +30,7 @@ TICK_CHAR = '■'
 DEFAULT_THRESHOLD = 5 # grey bar < DEFAULT_THRESHOLD >= green bar
 WIDTH = 60 # Graph width
 DONE = "done.txt"
+TODO = "todo.txt"
 
 # try to use xrange, which is faster
 try:
@@ -113,8 +114,11 @@ def print_blocks(label, count, step):
 # Based on Lately Addon:
 # https://github.com/emilerl/emilerl/tree/master/todo.actions.d
 def main(directory, cutoffDays = 7):
-    f = open(os.path.join(directory, DONE), 'r')
-    lines = f.readlines()
+    lines = []
+    files = [DONE, TODO]
+    for filename in files:
+        with open(os.path.join(directory, filename), 'r') as f:
+            lines.extend(f.readlines())
     today = datetime.datetime.today()
     cutoff =  today - datetime.timedelta(days=cutoffDays)
     dic = {}


### PR DESCRIPTION
This solves issue https://github.com/timpulver/todo.txt-graph/issues/2.

Read done tasks from `todo.txt`, in addition to the currently read `done.txt`.
Use case: some of the Todo-txt clients (e.g. iOS one) leave done tasks in `todo.txt` 
instead of moving them to `done.txt`. This PR makes those tasks seen by the graph action.