### PR TITLE
Remove header in usage string

### DIFF
--- a/graph
+++ b/graph
@@ -8,7 +8,6 @@ shift
 
 [ "$action" = "usage" ] && {
   echo ""
-  echo "  Visualize done tasks:"
   echo "    graph"
   echo "      Draws bar graphs visualizing the number of completed task per day."
   echo "      Optional argument (integer): number of days to visualize (default: 7)"


### PR DESCRIPTION
The header "Visualize data" does look nice when displayed in
`todo.sh help`, but sadly induces confusion: any task that
follows this action in the list looks gives the impression
that it is part of the same section and hence visualizes data.

Removing the header prevents this confusion (on which I stupidely
stumbled the first time :) )