### PR TITLE
Fixes for Macos Monterey to use python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # todo.txt-graph
 
+This is a fork to make it work with python3 in particular for MacOS Monterey.
+
 *A visualization-plugin for [todo.txt](http://todotxt.com/) – a command line todo application.*  
 
 ![Graph Image](https://cloud.githubusercontent.com/assets/1055819/11110492/dd8527fe-88fc-11e5-9957-2e03db505fbd.png)
@@ -11,7 +13,6 @@ As in Jerry Seinfeld’s [don’t break the chain](http://dontbreakthechain.com/
 ## Installation
 
 `cd` into your plugins folder (see [Installing Addons](https://github.com/ginatrapani/todo.txt-cli/wiki/Creating-and-Installing-Add-ons)), e.g.:
-
 
 ```
 cd ~/.todo.actions.d
@@ -74,8 +75,3 @@ Code used from:
 
 - [termgraph](https://github.com/mkaz/termgraph/blob/master/termgraph.py)
 - [lately](https://github.com/emilerl/emilerl/)
-
-
-
-
-

--- a/graph
+++ b/graph
@@ -21,6 +21,6 @@ shift
         python2 "$TODO_ACTIONS_DIR"/graph/graph.py "$TODO_FILE" "$DONE_FILE" $flag
   else
         # use default python 
-        python "$TODO_ACTIONS_DIR"/graph/graph.py "$TODO_FILE" "$DONE_FILE" $flag
+        python3 "$TODO_ACTIONS_DIR"/graph/graph.py "$TODO_FILE" "$DONE_FILE" $flag
   fi
 }

--- a/graph.py
+++ b/graph.py
@@ -75,7 +75,7 @@ class Colors(object):
 
     def __getattr__(self,key):
         if key not in CCODES.keys():
-            raise AttributeError, "Colors object has no attribute '%s'" % key
+            raise AttributeError("Colors object has no attribute '%s'" % key)
         else:
             if self.disabled:
                 return lambda x: x
@@ -149,7 +149,7 @@ def main(todo_file, done_file, cutoffDays = 7):
 
     # find out max value
     max = 0
-    for key, value in dic.iteritems():
+    for key, value in dic.items():
         if value > max:
             max = value
 
@@ -160,7 +160,7 @@ def main(todo_file, done_file, cutoffDays = 7):
 
     # display graph
     print()
-    for key, value in orderedDic.iteritems():
+    for key, value in orderedDic.items():
         print_blocks(key, value, step)
     print()
 
@@ -173,7 +173,7 @@ if __name__ == '__main__':
     if os.path.isfile(sys.argv[1]) and os.path.isfile(sys.argv[2]):
         if len(sys.argv) == 4: 
             main(sys.argv[1], sys.argv[2], int(sys.argv[3]))
-	else:
+        else:
             main(sys.argv[1], sys.argv[2])
     else:
         print("Error: %s or %s doesn't exist" % (sys.argv[1], sys.argv[2]))


### PR DESCRIPTION
MacOS Monterey doesn't ship with python3 anymore. These small changes fix the code to work with python3